### PR TITLE
Some fixes for broken functionality / errors related to newer gmod versions

### DIFF
--- a/lua/menu/custom/mainmenu.lua
+++ b/lua/menu/custom/mainmenu.lua
@@ -9,6 +9,7 @@ include( "achievements.lua" )
 include( "main.lua" )
 include( "_errors.lua" )
 include( "../background.lua" )
+include( "../crosshair_setup.lua" )
 
 pnlMainMenu = nil
 

--- a/lua/menu/custom/mainmenu.lua
+++ b/lua/menu/custom/mainmenu.lua
@@ -406,6 +406,11 @@ function PANEL:RefreshContent()
 
 end
 
+function PANEL:SetProblemCount( problems, severity )
+	
+	-- The lua menu doesn't have a problems menu. This function is only here to shut any errors up.
+end
+
 function PANEL:ScreenshotScan( folder )
 
 	local bReturn = false


### PR DESCRIPTION
This PR fixes 
1. The edit crosshair button in the Settings menu not working.
2. Error spam related to the apparent "lack of" problems menu functionality. (despite existing in the lua menu)