### PR TITLE
Fix addon right-click menu not working

### DIFF
--- a/lua/menu/custom/addons.lua
+++ b/lua/menu/custom/addons.lua
@@ -36,14 +36,14 @@ function PANEL:OnMouseReleased( mousecode )
 			m:AddSpacer()
 		end
 
-		m:AddOption( "Open Workshop Page", function() if ( self.Addon ) then return end steamworks.ViewFile( self.Addon.wsid ) end )
+		m:AddOption( "Open Workshop Page", function() if ( !self.Addon ) then return end steamworks.ViewFile( self.Addon.wsid ) end )
 		m:AddSpacer()
 		if ( steamworks.ShouldMountAddon( self.Addon.wsid ) ) then
-			m:AddOption( "Disable", function() if ( self.Addon ) then return end steamworks.SetShouldMountAddon( self.Addon.wsid, false ) steamworks.ApplyAddons() end )
+			m:AddOption( "Disable", function() if ( !self.Addon ) then return end steamworks.SetShouldMountAddon( self.Addon.wsid, false ) steamworks.ApplyAddons() end )
 		else
-			m:AddOption( "Enable", function() if ( self.Addon ) then return end steamworks.SetShouldMountAddon( self.Addon.wsid, true ) steamworks.ApplyAddons() end )
+			m:AddOption( "Enable", function() if ( !self.Addon ) then return end steamworks.SetShouldMountAddon( self.Addon.wsid, true ) steamworks.ApplyAddons() end )
 		end
-		m:AddOption( "Uninstall", function() if ( self.Addon ) then return end steamworks.Unsubscribe( self.Addon.wsid ) steamworks.ApplyAddons() end ) -- Do we need ApplyAddons here?
+		m:AddOption( "Uninstall", function() if ( !self.Addon ) then return end steamworks.Unsubscribe( self.Addon.wsid ) steamworks.ApplyAddons() end ) -- Do we need ApplyAddons here?
 		m:AddSpacer()
 		m:AddOption( "Cancel", function() end )
 		m:Open()


### PR DESCRIPTION
In commit cf2774782479c25e064108679ae0c86bdeb08423, a check was added to each of the click handlers in the addon context menu with the intent of preventing use of the `self.Addon` property if it is nil (as explained by the error in #53). However, the check is performed incorrectly - it tests if `self.Addon` is *not* nil, and if that condition succeeds, the click handler is aborted. This means the click handler would *not* be aborted if `self.Addon` *is* nil. I have fixed this by inverting the check condition. It could also be fixed by moving the intended functionality within the body of the `if` directive.